### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Cargo Resources provides a cargo command line tool and library, to help declare and collate resources within Cargo Crates."
 license = "GPL-3.0-or-later"
 
-homepage = "https://github.com/PeteEvans/cargo-resources"
+repository = "https://github.com/PeteEvans/cargo-resources"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.